### PR TITLE
非認証ユーザの場合は/signinに遷移するよう修正。ユーザテーブルにtokenを追加

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,4 +1,6 @@
 class AboutController < ApplicationController
+  before_action :authenticate_user!
+
   def me
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,8 @@ class User < ActiveRecord::Base
         provider: auth.provider,
         uid:      auth.uid,
         email:    auth.info.email,
-        password: Devise.friendly_token[0, 20]
+        password: Devise.friendly_token[0, 20],
+        token:    auth.credentials.token
       )
     end
     user

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,8 @@ module MerryDiet
     config.middleware.use(Rack::Config) do |env|
       env['api.tilt.root'] = Rails.root.join 'app', 'views', 'apis'
     end
+
+    config.autoload_paths << Rails.root.join('lib')
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,10 +244,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.failure_app = CustomFailure
+    # manager.intercept_401 = false
+    # manager.default_strategies(scope: :user).unshift :some_external_strategy
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/lib/custom_failure.rb
+++ b/lib/custom_failure.rb
@@ -1,0 +1,9 @@
+class CustomFailure < Devise::FailureApp
+  def redirect_url
+    '/signin'
+  end
+
+  # def respond
+  #   if http_auth?
+  # end
+end

--- a/lib/custom_failure.rb
+++ b/lib/custom_failure.rb
@@ -2,8 +2,4 @@ class CustomFailure < Devise::FailureApp
   def redirect_url
     '/signin'
   end
-
-  # def respond
-  #   if http_auth?
-  # end
 end


### PR DESCRIPTION
オリジナルのdevise認証ページに遷移していたので、/signinに遷移するよう修正しました。

それと、API呼び出し用のtokenが取得できていなかったので取得するよう修正しました。
