### PR TITLE
OAuth認証時にバックログのspace_idを保持するよう修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,6 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def backlog
-    @user = User.find_for_backlog_oauth(request.env['omniauth.auth'], current_user)
+    @user = User.find_for_backlog_oauth(request.env['omniauth.auth'], session['omniauth.backlog.space_id'], current_user)
 
     if @user.persisted?
       sign_in_and_redirect @user, event: :authentication

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
-  def self.find_for_backlog_oauth(auth, signed_in_resource = nil)
+  def self.find_for_backlog_oauth(auth, space_id, signed_in_resource = nil)
     user = User.where( provider: auth.provider, uid: auth.uid ).first
 
     unless user
@@ -14,7 +14,8 @@ class User < ActiveRecord::Base
         uid:      auth.uid,
         email:    auth.info.email,
         password: Devise.friendly_token[0, 20],
-        token:    auth.credentials.token
+        token:    auth.credentials.token,
+        space_id: space_id
       )
     end
     user

--- a/db/migrate/20150929050319_add_omniauth_to_users.rb
+++ b/db/migrate/20150929050319_add_omniauth_to_users.rb
@@ -4,6 +4,7 @@ class AddOmniauthToUsers < ActiveRecord::Migration
     add_column :users, :uid     , :string
     add_column :users, :name    , :string
     add_column :users, :token   , :string
+    add_column :users, :space_id, :string
 
     add_index :users, [:uid, :provider], unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20150929050319) do
     t.string   "uid"
     t.string   "name"
     t.string   "token"
+    t.string   "space_id"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
バックログAPI叩くときにspace_idが必要だったので修正しました。
